### PR TITLE
Fix unit test dependency injection

### DIFF
--- a/include.conf.js
+++ b/include.conf.js
@@ -1,14 +1,23 @@
 module.exports = [
   'client/lib/bower_components/angular/angular.min.js',
-  'client/lib/bower_components/angular-route/angular-route.min.js',
   'client/lib/bower_components/angular-ui-router/release/angular-ui-router.min.js',
   'client/app/app.js',
-  'client/app/services/geoLocation.js',
-  'client/app/services/dataFetcher.js',
-  'client/app/services/mapMaker.js',
-  'client/app/services/emergencyNumber.js',
-  'client/app/auth/auth.js',
-  'client/app/distressButton/distressButton.js',
+  'client/app/locationDataServices/geoLocationService.js',
+  'client/app/locationDataServices/dataFetcherService.js',
+  'client/app/locationDataServices/googleAPIServices/mapMakerService.js',
+  'client/app/locationDataServices/googleAPIServices/emergencyNumberService.js',
+  'client/app/auth/authService.js',
+  'client/app/auth/attachTokensService.js',
+  'client/app/distressButton/distressButtonService.js',
   'client/app/home/HomeCtrl.js',
-  'client/app/signup/signupController.js'
+  'client/app/signup/signupCtrl.js',
+  'client/app/emergencyContacts/contactEditorService.js',
+  'client/app/emergencyContacts/contactCtrl.js',
+  'client/app/signin/signinCtrl.js',
+  'client/app/policeMap/policeCtrl.js',
+  'client/app/hospitalMap/hospitalCtrl.js',
+  // 'client/app/navbar/navbarCtrl.js'
 ];
+
+
+

--- a/test/unit/utilities.js
+++ b/test/unit/utilities.js
@@ -3,23 +3,24 @@ var should = chai.should();
 var expect = chai.expect;
 
 describe('the DataFetcher and GeoLocation service methods', function() {
-    beforeEach(module('distress'));
+  var DataFetcher;
+  var GeoLocation;
+  var $log;
 
-    var DataFetcher;
-    var GeoLocation;
-    var _$log_;
+  beforeEach(module('distress'));
 
-    beforeEach(inject(function(_DataFetcher_, _GeoLocation_, _$log_) {
-      DataFetcher = _DataFetcher_;
-      GeoLocation = _GeoLocation_;
-      $log = _$log_;
-    }));
+  // https://docs.angularjs.org/api/ngMock/function/angular.mock.inject
+  beforeEach(inject(function(_DataFetcher_, _GeoLocation_, _$log_) {
+    DataFetcher = _DataFetcher_;
+    GeoLocation = _GeoLocation_;
+    $log = _$log_;
+  }));
 
-    it('should have all the necessary methods', function(){
-        expect(DataFetcher.getPoliceMap).to.not.be.undefined;
-        expect(DataFetcher.getHospitalMap).to.not.be.undefined;
-        expect(DataFetcher.getEmergencyNumber).to.not.be.undefined;
-        expect(GeoLocation.getLocation).to.not.be.undefined;
-        expect(GeoLocation.storeLocation).to.not.be.undefined;
-    });
+  it('should have all the necessary methods', function(){
+    expect(DataFetcher.getPoliceMap).to.not.be.undefined;
+    expect(DataFetcher.getHospitalMap).to.not.be.undefined;
+    expect(DataFetcher.getEmergencyNumber).to.not.be.undefined;
+    expect(GeoLocation.getLocation).to.not.be.undefined;
+    expect(GeoLocation.storeLocation).to.not.be.undefined;
+  });
 });


### PR DESCRIPTION
Previously, dependency injection failed for unit tests due to missing dependencies. Updating the dependency list in include.config.js fixed the issue. 

Also converted to two space indentation, in accordance with our style guide
